### PR TITLE
Updates proposal to the latest design

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Stage**: 2
 
+**Spec Text**: https://github.com/pzuraq/ecma262/pull/10
+
 This proposal seeks to extend the [Decorators](https://github.com/tc39/proposal-decorators)
 proposal by adding the ability for decorators to associate _metadata_ with the
 value being decorated.


### PR DESCRIPTION
Updates the proposal to pass a simple shared object between all decorators, which gets assigned to `Symbol.metadata` in the end of class definition.